### PR TITLE
Tabs!

### DIFF
--- a/admin/edit.php
+++ b/admin/edit.php
@@ -1,5 +1,9 @@
 <?php
 	session_start();
+	if(!$_GET['id']) {
+		header('Location: index.php');
+		exit;
+	}
 	include("../admin/secure.php");
 	$id = $_GET['id']; 
 	$reload = "<meta http-equiv=refresh content=\"0; URL=".$_SERVER['REQUEST_URI']."\">";

--- a/admin/edit.php
+++ b/admin/edit.php
@@ -1,12 +1,11 @@
 <?php
 	session_start();
-	include("secure.php");
+	include("../admin/secure.php");
 	$id = $_GET['id']; 
 	$reload = "<meta http-equiv=refresh content=\"0; URL=".$_SERVER['REQUEST_URI']."\">";
-	$reloadPic = "<meta http-equiv=refresh content=\"0; URL=".$_SERVER['REQUEST_URI']."#pscroll\">"; //Need to test
 	$vehicle = trim(($rows[0]["year"]==0000?'':$rows[0]["year"])." ".$rows[0]['make']." ".$rows[0]['model']." ".$rows[0]['trim']);
 
-	if(isset($_POST['SubmitAll'])) {	//Submit data for top half of page, including notes sections
+	if(isset($_POST['SubmitAll'])) {
 		$update->bindParam(':vin',$_POST['vin']); 
 		$update->bindParam(':year',$_POST['year']); 
 		$update->bindParam(':make',$_POST['make']); 
@@ -15,8 +14,6 @@
 		$update->bindParam(':miles',str_replace(',','',$_POST['miles'])); 
 		$update->bindParam(':owner',$_POST['owner']); 
 		$update->bindParam(':askprice',str_replace(str_split('$,'),'',$_POST['askprice'])); 
-		$update->bindParam(':intnotes',$_POST['intnotes']); 
-		$update->bindParam(':pubnotes',$_POST['pubnotes']); 
 		$update->bindParam(':status',$_POST['status']); 
 		$update->bindParam(':insured',($_POST['insured']?$_POST['insured']=1:$_POST['insured']=0));
 		$update->bindParam(':payment',$_POST['payment']);
@@ -24,58 +21,46 @@
 		$update->execute();
 		echo $reload;
 	}
+	if(isset($_POST['SubmitDesc'])) {
+		$updateDesc->bindParam(':pubnotes',$_POST['pubnotes']); 
+		$updateDesc->execute();
+		echo $reload;
+	}
+	if(isset($_POST['SubmitInternal'])) {
+		$updateInternal->bindParam(':intnotes',$_POST['intnotes']); 
+		$updateInternal->execute();
+		$_SESSION['edit'] = 'internal';
+		echo $reload;
+	}
 	if(isset($_POST['delPic'])) {
 		unlink($_POST["pic"]);						//Delete photo
 		$pDelete->bindParam(':pid',$_POST["pid"]);	//Delete database entry
 		$pDelete->execute();
+		$_SESSION['edit'] = 'photos';
 		echo "<script> window.location.replace('".$_SERVER['REQUEST_URI']."#".$_POST["oldpic"]."'); </script>";
 	}
-	if(isset($_POST['updatepic'])) {				//Update photo name
+	if(isset($_POST['updatepic'])) {				//Update photo name and size
 		rename($_POST["fullpic"],str_replace($_POST["oldpic"],$_POST["picname"],$_POST["fullpic"]));
-
-		ini_set('memory_limit', '128M');
-		$fn = $_POST["fullpic"];
-		$size = getimagesize($fn);
-		$ratio = $size[0]/$size[1]; // width/height
-		if($size[1]>500){
-			if( $ratio > 1) {
-				$height = 500;
-				$width = 500*$ratio;
-			}
-			else {
-				$width = 500*$ratio;
-				$height = 500;
-			}
-			$src = imagecreatefromstring(file_get_contents($fn));
-			$dst = imagecreatetruecolor($width,$height);
-			try {
-				imagecopyresampled($dst,$src,0,0,0,0,$width,$height,$size[0],$size[1]);
-				imagedestroy($src);
-				imagepng($dst,$_POST["fullpic"]); // adjust format as needed
-				imagedestroy($dst);			
-			} catch (Exception $e) {
-				echo 'An error occurred. Please take note of the following line(s) and click the link below.<br>';
-				echo 'Caught exception: ',  $e->getMessage(), "\n";
-				echo "<p><a href='.'>Admin Home</a></p>";
-			}
-		}
 		$pUpdate->bindParam(':pid',$_POST["pid"]);
 		$pUpdate->bindParam(':filename',$_POST["picname"]);
 		$pUpdate->execute();
-		echo "<script> window.location.replace('".$_SERVER['REQUEST_URI']."#".$_POST["oldpic"]."'); </script>";
+		$_SESSION['edit'] = 'photos';
+		echo "<script>window.location.replace('edit.php?id=".$id."'); </script>";
 	}
 	if(isset($_POST['delFile'])) {
 		unlink($_POST["file"]);						//Delete file
 		$fDelete->bindParam(':fid',$_POST["fid"]);	//Delete database entry
 		$fDelete->execute();
-		echo $reloadPic;
+		$_SESSION['edit'] = 'files';
+		echo $reload;
 	}
 	if(isset($_POST['updateFile'])) {							//Update file name
 		rename($_POST["fullFile"],str_replace($_POST["oldFile"],$_POST["filename"],$_POST["fullFile"]));
 		$fUpdate->bindParam(':fid',$_POST["fid"]);
 		$fUpdate->bindParam(':filename',$_POST["filename"]);
 		$fUpdate->execute();
-		echo $reloadPic;
+		$_SESSION['edit'] = 'files';
+		echo $reload;
 	}
 	if(isset($_POST['eupdate'])) {								//Expense update
 		$eUpdate->bindParam(':eid',$_POST["eid"]);
@@ -84,7 +69,8 @@
 		$eUpdate->bindParam(':desc',$_POST["desc"]);
 		$eUpdate->bindParam(':cost',str_replace('$','',$_POST["cost"]));
 		$eUpdate->execute();
-		echo $reloadPic;
+		$_SESSION['edit'] = 'expenses';
+		echo $reload;
 	}
 	if(isset($_POST['einsert'])) {								//Expense insert
 		$eInsert->bindParam(':vehicle',$_POST["vehicle"]);
@@ -93,227 +79,247 @@
 		$eInsert->bindParam(':desc',$_POST["desc"]);
 		$eInsert->bindParam(':cost',str_replace('$','',$_POST["cost"]));
 		$eInsert->execute();
-		echo $reloadPic;
+		$_SESSION['edit'] = 'expenses';
+		echo $reload;
 	}
 ?>
-<body onload="updateOwner()" class='darkbg'>
-	<script src="http://code.jquery.com/jquery-3.1.0.min.js"></script>
-	<script src="../files/edit.js"></script>
-	<script language="JavaScript" type="text/javascript"><!--
-		var ownersArray = <?php echo json_encode($oRows); ?>;
-		var thissite = 'http://<?php echo $_SERVER['SERVER_NAME'].$_SERVER['REQUEST_URI'];?>';-->
-	</script>
-	<form action="<?php echo htmlspecialchars($_SERVER["PHP_SELF"]);?>" method="post" style="padding-bottom:20px;">
-		<table class='bgblue bord5 p15 b-rad15 clear m-lrauto m-bottom25 bold'>
-			<tr><!-- Row 0 -->
-				<td colspan="12" class='center huge bold'>
-					<a href="../vehicle.php?id=<?php echo $rows[0]['id'];?>"><?php echo $vehicle;?></a><br/><hr size="3px"/>
-				</td>
-			</tr>
-			<tr><!-- Row 1 -->
-				<td>VIN: <?php
-						echo (strlen($rows[0]['vin'])==17? "(<a href='http://www.vindecoder.net/?vin=".$rows[0]['vin']."&submit=Decode' target='_blank'>Decode</a>)":"&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;");
-					?>
-				</td>
-				<td><input style="width:165px;" type="textbox" tabindex=1 name="vin" value="<?php echo strtoupper($rows[0]['vin'])?>"></td>
-				<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
-				<td>Year:</td>
-				<td><input style="width:90px;" type="textbox" tabindex=4 name="year" value="<?php echo ($rows[0]["year"]==0000?"":$rows[0]["year"]);?>"></td>
-				<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
-				<td>Owner:</td>
-				<td colspan=2>
-					<select id="ownerdd" tabindex=9 name="owner" onchange="updateOwner()">
-						<option value=0>Select Owner...</option>
-						<?php
-							foreach ($oRows as $ownerdd) {
-								($ownerdd['id'] == $rows[0]['owner']?$selected=' selected':$selected='');
-								echo "<option value=".$ownerdd['id'].$selected.">".$ownerdd['name']."</option>";
-							}
-						?>
-					</select>
-					<?php
-						if (!empty($rows[0]['owner'])) {
-							echo "<a id='oEdit' class='show' href=''>Edit</a><a id='oSave' class='noscreen' href=''>Save</a>";
-						}
-					?>
-				</td>
-				<td rowspan=5><?php echo ($pRows[0]['filename']?"<img src='../vehicles/".$id."/".$pRows[0]['filename']."' width=200px />":'');?></td>
-				<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
-				<td><center>Links:</center></td>
-			</tr>
-			<tr><!-- Row 2 -->
-				<td nowrap><?php echo ($rows[0]['status']=='Sold'?'Sale':'Asking');?> Price:</td>
-				<td><input style="width:165px;" type="textbox" tabindex=2 name="askprice" value="<?php 
-					if (strpos($rows[0]['askprice'], '$') === FALSE && trim($rows[0]['askprice']) !== "") {
-						echo '$'.number_format($rows[0]['askprice']);
-					}
-																?>"></td>
-				<td>&nbsp;</td>
-				<td>Make:</td>
-				<td><input style="width:90px;" type="textbox" name="make" tabindex=5 value="<?php echo $rows[0]['make']?>"></td>
-				<td>&nbsp;</td>
-				<td>Phone:</td>
-				<td><span id='phonenum' class='show'></span><input id='oPhone' type="text" class="noscreen" /></td>
-				<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
-				<td>&nbsp;</td>
-				<td nowrap><center><a href='../'>For Sale</a></center></td>
-			</tr>
-			<tr><!-- Row 3 -->
-				<td nowrap>Status:</td>
-				<td nowrap>
-					<select name="status" id="status" onchange="statusChange()" style="min-width:84px;" tabindex=3>
-					<?php
-						$statuses=array('Draft','For Sale','Sold','Delete');
-						foreach($statuses as $stat){
-							($stat == $rows[0]['status']?$selected=' selected':$selected='');
-							echo "<option value='".$stat."'".$selected.">".$stat."</option>\n";
-						}
-					?>
-					</select>
-					<select name="payment" id="payment" onchange="paymentType()" class="<?php echo ($rows[0]['status']!='Sold'?noscreen:'');?>">
-						<?php
-							$statuses=array('Cash','Payments','Trade');
-							foreach($statuses as $stat){
-								($stat==$rows[0]['payment']?$selected=' selected':$selected='');
-								echo "<option value='".$stat."'".$selected.">".$stat."</option>\n";
-							}
-						?>
-					</select>
-				</td>
-				<td>&nbsp;</td>
-				<td>Model:</td>
-				<td><input style="width:90px;" type="textbox" tabindex=6 name="model" value="<?php echo $rows[0]['model']?>"></td>
-				<td>&nbsp;</td>
-				<td>Email:</td>
-				<td><span id='emailadd' class='show'></span><input id='oEmail' type="text" class="noscreen" /></td>
-				<td colspan=3>&nbsp;</td>
-				<td nowrap><center><a href='.'>Admin Home</a></center></td>
-			</tr>
-			<tr><!-- Row 4 -->
-				<td>
-					<span id='buyer' class="<?php echo ($rows[0]['status']!='Sold'?noscreen:'');?>">Buyer:</span>
-					<span id="lblinsured" class="block" name="lblinsured"><a href="mailto:info@insurancecenterofbuffalo.com?subject=Auto%20Insurance&body=<?php echo $vehicle;?>%20-%20VIN:%20<?php echo strtoupper($rows[0]['vin'])?>" title="Send Email to Insurance Center of Buffalo">Insured?</a>:</span>
-				</td>
-				<td nowrap>
-					<input type="textbox" style="width:78px;" class="<?php echo ($rows[0]['status']!='Sold'?noscreen:'');?>" id='fname' name='fname' placeholder="First Name" value="">
-					<input type="textbox" style="width:78px;" class="<?php echo ($rows[0]['status']!='Sold'?noscreen:'');?>" id='lname' name='lname' placeholder="Last Name" value="">
-					<input type="checkbox" class="block" id="insured" name="insured" value='insured'<?php echo ($rows[0]['insured'] == 1?" checked='checked'":"")?>>
-				</td>
-				<td>&nbsp;</td>
-				<td>Trim:</td>
-				<td><input style="width:90px;" type="textbox" tabindex=7 name="trim" value="<?php echo $rows[0]['trim']?>"></td>
-				<td colspan=4><center><font class='red' id='notice'>&nbsp;</font></center></td>
-				<td colspan=3>&nbsp;</td>
-			</tr>
-			<tr><!-- Row 5 -->
-				<td><span id="lblsaledate" class="<?php echo ($rows[0]['status']!='Sold'?noscreen:'');?>">Sale Date:</span></td>
-				<td><input type="date" id="saledate" class="<?php echo ($rows[0]['status']!='Sold'?noscreen:'');?>" style="width:167px;" name="saledate"></td>
-				<td>&nbsp;</td>
-				<td>Miles:</td>
-				<td><input style="width:90px;" type="textbox" name="miles" tabindex=8 value="<?php echo number_format($rows[0]['miles'])?>"></td>
-				<td>&nbsp;</td>
-				<td colspan=2><center><input type="Submit" tabindex=12 name="SubmitAll" id="SubmitAll" value="Submit All Changes"></center></td>
-				<td colspan=3>&nbsp;</td>
-				<td><center><a href='<?php echo $logout;?>'>Logout</a></center></td>
-			</tr>
-		</table>
-		
-		<div class='center clear m-lrauto bold' style="width:90%;margin-top:25px;">
-			<div class='m-bottom25 bgblue tb-p15 b-rad15 fleft bord5' style="width:46%;">
-				Description:<br>
-				<textarea class="boxsizingBorder" tabindex=10 style="padding:10px;margin-top:5px;width:90%;height:500px" name="pubnotes"><?php echo $rows[0]['pubnotes'];?></textarea>
-			</div>
-			<div class='fright' style="width:46%;">
-				<div class='m-bottom25 bgblue tb-p15 b-rad15 bord5'>
-					Internal Only Notes:<br>
-					<textarea class="boxsizingBorder" tabindex=11 style="padding:10px;margin-top:5px;width:90%;height:175px" name="intnotes"><?php echo $rows[0]['intnotes']?></textarea>
-				</div>
-				<div class='m-top25 bgblue p15 b-rad15 bord5'>
-					Basic HTML to Use in Description
-					<table class='htmlTable'><tr><td class='b-right1'>
-					&lt;div class='noprint'&gt; ... &lt;/div&gt;<hr />
-					&lt;h1&gt; ... &lt;/h1&gt;<hr />
-					&lt;p&gt; ... &lt;/p&gt;<hr />
-					&lt;b&gt; ... &lt;/b&gt;<hr />
-					&lt;i&gt; ... &lt;/i&gt;<hr />
-					&lt;u&gt; ... &lt;/u&gt;<hr />
-					&lt;font color="red"&gt; ... &lt;/font&gt;
-					</td><td>
-					Add to text area to hide when printing<hr />
-					Heading (1 - 6, big to small)<hr />
-					Paragraph of Text<hr />
-					<b>Bold Text</b><hr />
-					<i>Italic Text</i><hr />
-					<u>Underline Text</u><hr />
-					<font color="red">Color Text</font>
-					</td></tr></table>
-				</div>
-			</div>
+<body class='darkbg'>
+	<div id="adminSidenav" class="adminsidenav"><?php require_once("../files/menu.php");?></div>
+	<div id="adminMain">
+		<div class="adminContainer" onclick="myFunction(this)">
+		  <div class="bar1"></div>
+		  <div class="bar2"></div>
+		  <div class="bar3"></div>
 		</div>
-		<hr width="80%" size="5" color="red" />
-	</form>
-	<div class='center clear m-lrauto bold' style="width:90%;">
-		<div class='fleft' style="width:44%;min-width:450px;">
-			<div id='expenses' class='bgblue p15 b-rad15 bord5' style="margin-bottom:50px;">
-				Expenses:<br><center><table><tr><td width='80px'>Date</td><td width='205px'>Description</td><td>Cost</td></tr>
-				<?php 
-					if (!empty($eRows)) {
-						foreach ($eRows as $exp) {
-							$date = ($exp['date'] != '0000-00-00' && $exp['date'] != '1969-12-31'?date('m/d/Y',strtotime($exp['date'])):"");
-							echo "<tr><td nowrap colspan=3><form action='".htmlspecialchars($_SERVER['PHP_SELF'])."' method='post'><input type='hidden' name='eid' value='".$exp['id']."'><input style='width:75px;' type='textbox' name='date' value='".$date."'>&nbsp;<input style='width:200px;' type='textbox' name='desc' value=\"".$exp['description']."\">&nbsp;<input style='width:50px;' type='textbox' name='cost' value='".$exp['cost']."'>&nbsp;<input type='submit' name='eupdate' value='Update'></form></td></tr>";
-						}
-						echo "<tr><td nowrap colspan=2 align=right>Total: </td><td class='red'>$".$eTotal[0]['Total']."</td></tr>";
-					}
-				?>
-				<tr><td nowrap colspan=3><form action='<?php echo htmlspecialchars($_SERVER["PHP_SELF"]);?>' method='post'><input type='hidden' name='vehicle' value='<?php echo $_GET['id']?>'><input style='width:75px;' type='textbox' name='date' value=''>&nbsp;<input style='width:200px;' type='textbox' name='desc' value=''>&nbsp;<input style='width:50px;' type='textbox' name='cost' value=''>&nbsp;<input type='submit' name='einsert' value='Insert'></form></td></tr>
-				</table></center>
-			</div>
-			<div class='bgblue p15 b-rad15 bord5' style="margin-bottom:50px;">
-				Files:<br>
-				<div>
-					<form action="upload_file.php?id=<?php echo $rows[0]['id'];?>" method="post" enctype="multipart/form-data">
-					  <input name="files[]" type="file" multiple /><input type="submit" onclick='loading1()' value="Send files" />
+		<div id="mainContainer" class="bgblue bord5 b-rad15 clear m-lrauto m-bottom25 bold">
+			<form action="<?php echo htmlspecialchars($_SERVER["REQUEST_URI"]);?>" method="post">
+				<table style="padding:15px;">
+					<tr><!-- Row 1 -->
+						<td colspan="12" class='center huge bold'>
+							<a href="../vehicle.php?id=<?php echo $rows[0]['id'];?>"><?php echo $vehicle;?></a><br/><hr size="3px"/>
+						</td>
+					</tr>
+					<tr><!-- Row 2 -->
+						<td nowrap>VIN: <?php
+								echo (strlen($rows[0]['vin'])==17? "(<a href='http://www.vindecoder.net/?vin=".$rows[0]['vin']."&submit=Decode' target='_blank'>Decode</a>)":"&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;");
+							?>
+						</td>
+						<td><input style="width:165px;" type="textbox" tabindex=1 name="vin" value="<?php echo strtoupper($rows[0]['vin'])?>"></td>
+						<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+						<td>Year:</td>
+						<td><input style="width:90px;" type="textbox" tabindex=4 name="year" value="<?php echo ($rows[0]["year"]==0000?"":$rows[0]["year"]);?>"></td>
+						<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+						<td>Owner:</td>
+						<td colspan=2 nowrap>
+							<select id="ownerdd" tabindex=9 name="owner" onchange="updateOwner()">
+								<option value=0>Select Owner...</option>
+								<?php
+									foreach ($oRows as $ownerdd) {
+										($ownerdd['id'] == $rows[0]['owner']?$selected=' selected':$selected='');
+										echo "<option value=".$ownerdd['id'].$selected.">".$ownerdd['name']."</option>";
+									}
+								?>
+							</select>
+							<?php
+								if (!empty($rows[0]['owner'])) {
+									echo "<a id='oEdit' class='show' href=''>Edit</a><a id='oSave' class='noscreen' href=''>Save</a>";
+								}
+							?>
+						</td>
+						<td rowspan=5><?php echo ($pRows[0]['filename']?"<img src='../vehicles/".$id."/".$pRows[0]['filename']."' width=200px />":'');?></td>
+						<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+					</tr>
+					<tr><!-- Row 3 -->
+						<td nowrap><?php echo ($rows[0]['status']=='Sold'?'Sale':'Asking');?> Price:</td>
+						<td><input style="width:165px;" type="textbox" tabindex=2 name="askprice" value="<?php 
+							if (strpos($rows[0]['askprice'], '$') === FALSE && trim($rows[0]['askprice']) !== "") {
+								echo '$'.number_format($rows[0]['askprice']);
+							}
+																		?>"></td>
+						<td>&nbsp;</td>
+						<td>Make:</td>
+						<td><input style="width:90px;" type="textbox" name="make" tabindex=5 value="<?php echo $rows[0]['make']?>"></td>
+						<td>&nbsp;</td>
+						<td>Phone:</td>
+						<td><span id='phonenum' class='show'></span><input id='oPhone' type="text" class="noscreen" /></td>
+						<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
+						<td>&nbsp;</td>
+					</tr>
+					<tr><!-- Row 4 -->
+						<td nowrap>Status:</td>
+						<td nowrap>
+							<select name="status" id="status" onchange="statusChange()" style="min-width:84px;" tabindex=3>
+							<?php
+								$statuses=array('Draft','For Sale','Sold','Delete');
+								foreach($statuses as $stat){
+									($stat == $rows[0]['status']?$selected=' selected':$selected='');
+									echo "<option value='".$stat."'".$selected.">".$stat."</option>\n";
+								}
+							?>
+							</select>
+							<select name="payment" id="payment" onchange="paymentType()" class="<?php echo ($rows[0]['status']!='Sold'?noscreen:'');?>">
+								<?php
+									$statuses=array('Cash','Payments','Trade');
+									foreach($statuses as $stat){
+										($stat==$rows[0]['payment']?$selected=' selected':$selected='');
+										echo "<option value='".$stat."'".$selected.">".$stat."</option>\n";
+									}
+								?>
+							</select>
+						</td>
+						<td>&nbsp;</td>
+						<td>Model:</td>
+						<td><input style="width:90px;" type="textbox" tabindex=6 name="model" value="<?php echo $rows[0]['model']?>"></td>
+						<td>&nbsp;</td>
+						<td>Email:</td>
+						<td><span id='emailadd' class='show'></span><input id='oEmail' type="text" class="noscreen" /></td>
+						<td colspan=3>&nbsp;</td>
+					</tr>
+					<tr><!-- Row 5 -->
+						<td>
+							<span id='buyer' class="<?php echo ($rows[0]['status']!='Sold'?noscreen:'');?>">Buyer:</span>
+							<span id="lblinsured" class="block" name="lblinsured"><a href="mailto:info@insurancecenterofbuffalo.com?subject=Auto%20Insurance&body=<?php echo $vehicle;?>%20-%20VIN:%20<?php echo strtoupper($rows[0]['vin'])?>" title="Send Email to Insurance Center of Buffalo">Insured?</a>:</span>
+						</td>
+						<td nowrap>
+							<input type="textbox" style="width:78px;" class="<?php echo ($rows[0]['status']!='Sold'?noscreen:'');?>" id='fname' name='fname' placeholder="First Name" value="">
+							<input type="textbox" style="width:78px;" class="<?php echo ($rows[0]['status']!='Sold'?noscreen:'');?>" id='lname' name='lname' placeholder="Last Name" value="">
+							<input type="checkbox" class="block" id="insured" name="insured" value='insured'<?php echo ($rows[0]['insured'] == 1?" checked='checked'":"")?>>
+						</td>
+						<td>&nbsp;</td>
+						<td>Trim:</td>
+						<td><input style="width:90px;" type="textbox" tabindex=7 name="trim" value="<?php echo $rows[0]['trim']?>"></td>
+						<td colspan=4><center><font class='red' id='notice'>&nbsp;</font></center></td>
+						<td colspan=2>&nbsp;</td>
+					</tr>
+					<tr><!-- Row 6 -->
+						<td><span id="lblsaledate" class="<?php echo ($rows[0]['status']!='Sold'?noscreen:'');?>">Sale Date:</span></td>
+						<td><input type="date" id="saledate" class="<?php echo ($rows[0]['status']!='Sold'?noscreen:'');?>" style="width:167px;" name="saledate"></td>
+						<td>&nbsp;</td>
+						<td>Miles:</td>
+						<td><input style="width:90px;" type="textbox" name="miles" tabindex=8 value="<?php echo number_format($rows[0]['miles'])?>"></td>
+						<td>&nbsp;</td>
+						<td colspan=2><center><input type="Submit" tabindex=12 name="SubmitAll" id="SubmitAll" value="Submit All Changes"></center></td>
+						<td colspan=3>&nbsp;</td>
+					</tr>
+				</table>
+			</form>
+				<br/><hr><br/>
+				<button class="tablink width20" onclick="openTab('Description', this, 'left')"<?php echo (!$_SESSION['edit']?" id=\"defaultTab\"":"");?>>Description</button>
+				<button class="tablink width20" onclick="openTab('Internal', this, 'middle')"<?php echo ($_SESSION['edit']=='internal'?" id=\"defaultTab\"":"");?>>Internal</button>
+				<button class="tablink width20" onclick="openTab('Expenses', this, 'middle')"<?php echo ($_SESSION['edit']=='expenses'?" id=\"defaultTab\"":"");?>>Expenses</button>
+				<button class="tablink width20" onclick="openTab('Files', this, 'middle')"<?php echo ($_SESSION['edit']=='files'?" id=\"defaultTab\"":"");?>>Files</button>
+				<button class="tablink width20" onclick="openTab('Photos', this, 'right')"<?php echo ($_SESSION['edit']=='photos'?" id=\"defaultTab\"":"");?>>Photos</button>
+				<div id="Description" class="tabcontent">
+					<form action="<?php echo htmlspecialchars($_SERVER["REQUEST_URI"]);?>" method="post">
+						<textarea class="boxsizingBorder" tabindex=10 style="padding:10px;margin-top:5px;width:90%;height:200px" name="pubnotes"><?php echo $rows[0]['pubnotes'];?></textarea><br/>
+						<input type="Submit" tabindex=11 name="SubmitDesc" id="SubmitDesc" value="Save">
 					</form>
-					<br><center><img src='../files/loading_anim.gif' class='noscreen' id='loading1' width=100px></center>
 				</div>
-				<hr class='m-top25 m-bottom25 center red' style="width:80%;" />
-				<div><center>
+				<div id="Internal" class="tabcontent">
+					<form action="<?php echo htmlspecialchars($_SERVER["REQUEST_URI"]);?>" method="post">
+						<textarea class="boxsizingBorder" tabindex=12 style="padding:10px;margin-top:5px;width:90%;height:200px" name="intnotes"><?php echo $rows[0]['intnotes']?></textarea><br/>
+						<input type="Submit" tabindex=13 name="SubmitInternal" id="SubmitInternal" value="Save">
+					</form>
+				</div>
+			<div id="Expenses" class="tabcontent">
+				<div class='bgblue p15 b-rad15 bord5'>
+					Expenses:<br><center><table><tr><td width='80px'>Date</td><td width='205px'>Description</td><td>Cost</td></tr>
 					<?php 
-						if ($fRows) {
-							echo "<table class='photos'>";
-							foreach ($fRows as $file) {
-								$path="../vehicles/".$id."/".$file['filename'];
-								echo "\n<tr><td nowrap align='right'><form action='".htmlspecialchars($_SERVER["PHP_SELF"])."' method='post'><a class='show' href='".$path."' target='_blank'>".$file['filename']."</a><input type='hidden' name='fullFile' value='".$path."'><input type='hidden' name='oldFile' value='".$file['filename']."'><input class='noscreen' type='textbox' style='width:150px' name='filename' value='".$file['filename']."''><input type='hidden' name='fid' value='".$file['id']."'>&nbsp;&nbsp;&nbsp;&nbsp;<a href='#' class='show fedit hide'>Edit</a>&nbsp;&nbsp;&nbsp;&nbsp;<input class='noscreen' type='submit' name='updateFile' value='Update'></form></td>\n<td><form action='".htmlspecialchars($_SERVER["PHP_SELF"])."' method='post'><input type='hidden' name='file' value='".$path."'><input type='hidden' name='fid' value='".$file['id']."'><input type='submit' name='delFile' value='Delete'></form></td></tr>\n";
-								
+						if (!empty($eRows)) {
+							foreach ($eRows as $exp) {
+								$date = ($exp['date'] != '0000-00-00' && $exp['date'] != '1969-12-31'?date('m/d/Y',strtotime($exp['date'])):"");
+								echo "<tr><td nowrap colspan=3><form action='".htmlspecialchars($_SERVER['REQUEST_URI'])."' method='post'><input type='hidden' name='eid' value='".$exp['id']."'><input style='width:75px;' type='textbox' name='date' value='".$date."'>&nbsp;<input style='width:200px;' type='textbox' name='desc' value=\"".$exp['description']."\">&nbsp;<input style='width:50px;' type='textbox' name='cost' value='".$exp['cost']."'>&nbsp;<input type='submit' name='eupdate' value='Update'></form></td></tr>";
 							}
-							echo "</table>";
-						} else {echo ("\nThere are no files for this vehicle.");}
-					?>
-				</center></div>
-			</div>
-		</div>
-		<div class='bgblue p15 b-rad15 fright bord5' style="margin-bottom:50px;width:43.5%;min-width:500px;">
-			Photos:<br>
-			<div>
-				<form action="upload_file.php?id=<?php echo $rows[0]['id'];?>" method="post" enctype="multipart/form-data">
-				  <input name="photos[]" type="file" multiple accept="image/*" /><input type="submit" onclick='loading2()' value="Send files" />
-				</form>
-				<br><center><img src='../files/loading_anim.gif' class='noscreen' id='loading2' width=100px></center>
-			</div>
-			<hr class='m-top25 m-bottom25 center red' style="width:80%;" />
-			<div><center>
-				<?php 
-					if ($pRows) {
-						echo "<table class='photos'>";
-						foreach ($pRows as $image) {
-							$path="../vehicles/".$id."/".$image['filename'];
-							echo "\n<tr><td><a href='".$path."' target='_blank' id='".$image['filename']."'><img src='".$path."' width=200px /></a></td>\n<td nowrap><form action='".htmlspecialchars($_SERVER["PHP_SELF"])."' method='post'><input type='hidden' name='fullpic' value='".$path."'><input type='hidden' name='oldpic' value='".$image['filename']."'><input type='textbox' style='width:150px' name='picname' value='".$image['filename']."''><input type='hidden' name='pid' value='".$image['id']."'><input type='submit' name='updatepic' value='Update'></form></td>\n<td><form action='".htmlspecialchars($_SERVER["PHP_SELF"])."' method='post'><input type='hidden' name='pic' value='".$path."'><input type='hidden' name='pid' value='".$image['id']."'><input type='submit' name='delPic' value='Delete'></form></td></tr>\n";
+							echo "<tr><td nowrap colspan=2 align=right>Total: </td><td class='red'>$".$eTotal[0]['Total']."</td></tr>";
 						}
-						echo "</table>";
-					} else {echo ("\nThere are no photos for this vehicle.");}
-				?>
-			</center></div>
+					?>
+					<tr><td nowrap colspan=3><form action='<?php echo htmlspecialchars($_SERVER["REQUEST_URI"]);?>' method='post'><input type='hidden' name='vehicle' value='<?php echo $_GET['id']?>'><input style='width:75px;' type='textbox' name='date' value=''>&nbsp;<input style='width:200px;' type='textbox' name='desc' value=''>&nbsp;<input style='width:50px;' type='textbox' name='cost' value=''>&nbsp;<input type='submit' name='einsert' value='Insert'></form></td></tr>
+					</table></center>
+				</div>
+			</div>
+			<div id="Files" class="tabcontent">
+				<div class='bgblue p15 b-rad15 bord5'>
+					Files:<br>
+					<div>
+						<form action="upload_file.php?id=<?php echo $rows[0]['id'];?>" method="post" enctype="multipart/form-data">
+						  <input name="files[]" type="file" multiple /><input type="submit" value="Send files" />
+						</form>
+						<br><center><img src='../files/loading_anim.gif' class='noscreen' id='loading1' width=100px></center>
+					</div>
+					<hr class='m-top25 m-bottom25 center red' style="width:80%;" />
+					<div><center>
+						<?php 
+							if ($fRows) {
+								echo "<table class='photos'>";
+								foreach ($fRows as $file) {
+									$path="../vehicles/".$id."/".$file['filename'];
+									echo "\n<tr><td nowrap align='right'>
+									<form action='".htmlspecialchars($_SERVER["REQUEST_URI"])."' method='post'>
+										<a class='show' href='".$path."' target='_blank'>".$file['filename']."</a>
+										<input type='hidden' name='fullFile' value='".$path."'>
+										<input type='hidden' name='oldFile' value='".$file['filename']."'>
+										<input class='noscreen' type='textbox' style='width:150px' name='filename' value='".$file['filename']."''>
+										<input type='hidden' name='fid' value='".$file['id']."'>
+										&nbsp;&nbsp;&nbsp;&nbsp;<a href='.' class='show fedit hide'>Edit</a>&nbsp;&nbsp;&nbsp;&nbsp;
+										<input class='noscreen' type='submit' name='updateFile' value='Update'>
+									</form></td>\n<td>
+									<form action='".htmlspecialchars($_SERVER["REQUEST_URI"])."' method='post'>
+										<input type='hidden' name='file' value='".$path."'>
+										<input type='hidden' name='fid' value='".$file['id']."'>
+										<input type='submit' name='delFile' value='Delete'>
+									</form></td></tr>\n";
+								}
+								echo "</table>";
+							} else {echo ("\nThere are no files for this vehicle.");}
+						?>
+					</center></div>
+				</div>
+			</div>
+			<div id="Photos" class="tabcontent">
+				<div class='bgblue p15 b-rad15 bord5'>
+					Photos:<br>
+					<div>
+						<form action="upload_file.php?id=<?php echo $rows[0]['id'];?>" method="post" enctype="multipart/form-data">
+						  <input name="photos[]" type="file" multiple accept="image/*" /><input type="submit" onclick='loading2()' value="Send files" />
+						</form>
+						<br><center><img src='../files/loading_anim.gif' class='noscreen' id='loading2' width=100px></center>
+					</div>
+					<hr class='m-top25 m-bottom25 center red' style="width:80%;" />
+					<div><center>
+						<?php 
+							if ($pRows) {
+								echo "<table class='photos'>";
+								foreach ($pRows as $image) {
+									$path="../vehicles/".$id."/".$image['filename'];
+									echo "\n<tr><td><a href='".$path."' target='_blank' id='".$image['filename']."'><img src='".$path."' width=200px /></a></td>\n
+									<td nowrap>
+										<form action='".htmlspecialchars($_SERVER["REQUEST_URI"])."' method='post'>
+										<input type='hidden' name='fullpic' value='".$path."'>
+										<input type='hidden' name='oldpic' value='".$image['filename']."'>
+										<input type='textbox' style='width:150px' name='picname' value='".$image['filename']."''>
+										<input type='hidden' name='pid' value='".$image['id']."'>
+										<input type='submit' name='updatepic' value='Update'>
+										</form>
+									</td>\n
+									<td>
+										<form action='".htmlspecialchars($_SERVER["REQUEST_URI"])."' method='post'>
+											<input type='hidden' name='pic' value='".$path."'>
+											<input type='hidden' name='pid' value='".$image['id']."'>
+											<input type='submit' name='delPic' value='Delete'>
+										</form>
+									</td></tr>\n";
+								}
+								echo "</table>";
+							} else {echo ("\nThere are no photos for this vehicle.");}
+						?>
+					</center></div>
+				</div>
+			</div>
 		</div>
 	</div>
+	<script src="http://code.jquery.com/jquery-3.1.0.min.js"></script>
+	<script src="../files/admin.js"></script>
+	<script src="../files/edit.js"></script>
+	<script language="JavaScript" type="text/javascript">document.getElementById("defaultTab").click();</script>
 </body>
 </html>

--- a/admin/edit.php
+++ b/admin/edit.php
@@ -9,7 +9,7 @@
 	$reload = "<meta http-equiv=refresh content=\"0; URL=".$_SERVER['REQUEST_URI']."\">";
 	$vehicle = trim(($rows[0]["year"]==0000?'':$rows[0]["year"])." ".$rows[0]['make']." ".$rows[0]['model']." ".$rows[0]['trim']);
 
-	if(isset($_POST['SubmitAll'])) {
+	if(isset($_POST['SubmitTop'])) {
 		$update->bindParam(':vin',$_POST['vin']); 
 		$update->bindParam(':year',$_POST['year']); 
 		$update->bindParam(':make',$_POST['make']); 
@@ -87,14 +87,10 @@
 		echo $reload;
 	}
 ?>
-<body class='darkbg'>
+<body class='darkbg' onLoad="updateOwner()">
 	<div id="adminSidenav" class="adminsidenav"><?php require_once("../files/menu.php");?></div>
 	<div id="adminMain">
-		<div class="adminContainer" onclick="myFunction(this)">
-		  <div class="bar1"></div>
-		  <div class="bar2"></div>
-		  <div class="bar3"></div>
-		</div>
+		<div class="adminContainer" onclick="myFunction(this)"><div class="bar1"></div><div class="bar2"></div><div class="bar3"></div></div>
 		<div id="mainContainer" class="bgblue bord5 b-rad15 clear m-lrauto m-bottom25 bold">
 			<form action="<?php echo htmlspecialchars($_SERVER["REQUEST_URI"]);?>" method="post">
 				<table style="padding:15px;">
@@ -114,7 +110,7 @@
 						<td><input style="width:90px;" type="textbox" tabindex=4 name="year" value="<?php echo ($rows[0]["year"]==0000?"":$rows[0]["year"]);?>"></td>
 						<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
 						<td>Owner:</td>
-						<td colspan=2 nowrap>
+						<td nowrap>
 							<select id="ownerdd" tabindex=9 name="owner" onchange="updateOwner()">
 								<option value=0>Select Owner...</option>
 								<?php
@@ -124,12 +120,8 @@
 									}
 								?>
 							</select>
-							<?php
-								if (!empty($rows[0]['owner'])) {
-									echo "<a id='oEdit' class='show' href=''>Edit</a><a id='oSave' class='noscreen' href=''>Save</a>";
-								}
-							?>
 						</td>
+						<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
 						<td rowspan=5><?php echo ($pRows[0]['filename']?"<img src='../vehicles/".$id."/".$pRows[0]['filename']."' width=200px />":'');?></td>
 						<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
 					</tr>
@@ -145,7 +137,7 @@
 						<td><input style="width:90px;" type="textbox" name="make" tabindex=5 value="<?php echo $rows[0]['make']?>"></td>
 						<td>&nbsp;</td>
 						<td>Phone:</td>
-						<td><span id='phonenum' class='show'></span><input id='oPhone' type="text" class="noscreen" /></td>
+						<td><span id='phonenum' class='show'></span></td>
 						<td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>
 						<td>&nbsp;</td>
 					</tr>
@@ -176,7 +168,7 @@
 						<td><input style="width:90px;" type="textbox" tabindex=6 name="model" value="<?php echo $rows[0]['model']?>"></td>
 						<td>&nbsp;</td>
 						<td>Email:</td>
-						<td><span id='emailadd' class='show'></span><input id='oEmail' type="text" class="noscreen" /></td>
+						<td><span id='emailadd' class='show'></span></td>
 						<td colspan=3>&nbsp;</td>
 					</tr>
 					<tr><!-- Row 5 -->
@@ -202,7 +194,7 @@
 						<td>Miles:</td>
 						<td><input style="width:90px;" type="textbox" name="miles" tabindex=8 value="<?php echo number_format($rows[0]['miles'])?>"></td>
 						<td>&nbsp;</td>
-						<td colspan=2><center><input type="Submit" tabindex=12 name="SubmitAll" id="SubmitAll" value="Submit All Changes"></center></td>
+						<td colspan=2><center><input type="Submit" tabindex=12 name="SubmitTop" id="SubmitTop" value="Save"></center></td>
 						<td colspan=3>&nbsp;</td>
 					</tr>
 				</table>
@@ -246,7 +238,7 @@
 					Files:<br>
 					<div>
 						<form action="upload_file.php?id=<?php echo $rows[0]['id'];?>" method="post" enctype="multipart/form-data">
-						  <input name="files[]" type="file" multiple /><input type="submit" value="Send files" />
+						  <input name="files[]" type="file" multiple /><input type="submit" value="Upload files" />
 						</form>
 						<br><center><img src='../files/loading_anim.gif' class='noscreen' id='loading1' width=100px></center>
 					</div>
@@ -284,7 +276,7 @@
 					Photos:<br>
 					<div>
 						<form action="upload_file.php?id=<?php echo $rows[0]['id'];?>" method="post" enctype="multipart/form-data">
-						  <input name="photos[]" type="file" multiple accept="image/*" /><input type="submit" onclick='loading2()' value="Send files" />
+						  <input name="photos[]" type="file" multiple accept="image/*" /><input type="submit" onclick='loading2()' value="Upload photos" />
 						</form>
 						<br><center><img src='../files/loading_anim.gif' class='noscreen' id='loading2' width=100px></center>
 					</div>
@@ -324,6 +316,10 @@
 	<script src="http://code.jquery.com/jquery-3.1.0.min.js"></script>
 	<script src="../files/admin.js"></script>
 	<script src="../files/edit.js"></script>
-	<script language="JavaScript" type="text/javascript">document.getElementById("defaultTab").click();</script>
+	<script language="JavaScript" type="text/javascript">
+		var ownersArray = <?php echo json_encode($oRows); ?>;
+		var thissite = 'http://<?php echo $_SERVER['SERVER_NAME'].$_SERVER['REQUEST_URI'];?>';
+		document.getElementById("defaultTab").click();
+	</script>
 </body>
 </html>

--- a/admin/upload_file.php
+++ b/admin/upload_file.php
@@ -1,4 +1,5 @@
 <?php
+	session_start();
 	ini_set('memory_limit', '128M');
 	include("secure.php");
 
@@ -40,6 +41,7 @@
 	try {
 		if (isset($_FILES["photos"])) {
 			$photos = rearrange($_FILES["photos"]);
+			$_SESSION['edit']='photos';
 			foreach ($photos as $photo) {
 				$inc += 1;
 				resize($photo);
@@ -71,6 +73,7 @@
 			}
 		} elseif (isset($_FILES["files"])) {
 			$files = rearrange($_FILES["files"]);
+			$_SESSION['edit']='files';
 			foreach ($files as $file) {
 				$inc += 1; 
 				if ($file["size"] < 10000000 && $file["error"] == 0) {

--- a/files/admin.js
+++ b/files/admin.js
@@ -24,7 +24,7 @@ function myFunction(x) {
 	document.getElementById("adminSidenav").classList.toggle("change");
 	document.getElementById("adminMain").classList.toggle("change");
 }
-function openTab(tabName,elmnt) {
+function openTab(tabName,elmnt,position) {
     var i, tabcontent, tablinks;
     tabcontent = document.getElementsByClassName("tabcontent");
     for (i = 0; i < tabcontent.length; i++) {
@@ -44,6 +44,8 @@ function openTab(tabName,elmnt) {
 	elmnt.style.fontWeight = 'bold';
 	elmnt.style.borderBottom = 'none';
 	elmnt.style.borderTop = '3px solid blue';
-	if (tabName == 'Database' || tabName == 'Owners') {elmnt.style.borderRight = '1px solid';}
+	if (position == 'left' || position == 'middle') {elmnt.style.borderRight = '1px solid';}
+	if (position == 'right' || position == 'middle') {elmnt.style.borderLeft = '1px solid';}
+/* 	if (tabName == 'Database' || tabName == 'Owners' || tabName == 'Description') {elmnt.style.borderRight = '1px solid';}
 	if (tabName == 'Users' || tabName == 'Owners') {elmnt.style.borderLeft = '1px solid';}
-}
+ */}

--- a/files/admin.js
+++ b/files/admin.js
@@ -24,3 +24,26 @@ function myFunction(x) {
 	document.getElementById("adminSidenav").classList.toggle("change");
 	document.getElementById("adminMain").classList.toggle("change");
 }
+function openTab(tabName,elmnt) {
+    var i, tabcontent, tablinks;
+    tabcontent = document.getElementsByClassName("tabcontent");
+    for (i = 0; i < tabcontent.length; i++) {
+        tabcontent[i].style.display = "none";
+    }
+    tablinks = document.getElementsByClassName("tablink");
+    for (i = 0; i < tablinks.length; i++) {
+        tablinks[i].style.backgroundColor = "#daecee";
+		tablinks[i].style.fontWeight = "normal";
+		tablinks[i].style.borderBottom = '1px solid';
+		tablinks[i].style.borderTop = 'none';
+		tablinks[i].style.borderRight = 'none';
+		tablinks[i].style.borderLeft = 'none';
+    }
+    document.getElementById(tabName).style.display = "block";
+    elmnt.style.backgroundColor = 'silver';
+	elmnt.style.fontWeight = 'bold';
+	elmnt.style.borderBottom = 'none';
+	elmnt.style.borderTop = '3px solid blue';
+	if (tabName == 'Database' || tabName == 'Owners') {elmnt.style.borderRight = '1px solid';}
+	if (tabName == 'Users' || tabName == 'Owners') {elmnt.style.borderLeft = '1px solid';}
+}

--- a/files/edit.js
+++ b/files/edit.js
@@ -120,3 +120,12 @@ function substr_replace(str, replace, start, length) {		//php substr_replace in 
   if (length < 0) {length = length + str.length - start;}
   return str.slice(0, start) + replace.substr(0, length) + replace.slice(length) + str.slice(start + length);
 }
+//Testing Textarea Char Limit ( onkeyup="countChar(this)")
+/* function countChar(val) {
+	var len = val.value.length;
+	if (len >= 700) {
+		val.value = val.value.substring(0, 700);
+	} else {
+		$('#charNum').text(700 - len);
+	}
+} */

--- a/files/edit.js
+++ b/files/edit.js
@@ -45,15 +45,16 @@ function updateOwner() {
 	var e = document.getElementById("ownerdd");
 	var owner = e.options[e.selectedIndex].value;
 	if (owner !=0) {
-		document.getElementById("phonenum").innerHTML = ownersArray[owner-1]['phone'];
-		document.getElementById("emailadd").innerHTML = ownersArray[owner-1]['email'];
-		document.getElementById("oPhone").value = ownersArray[owner-1]['phone'];
-		document.getElementById("oEmail").value = ownersArray[owner-1]['email'];
+		for (var i = 0, len = ownersArray.length; i < len; i++) {
+			if (owner == ownersArray[i].id) {
+				document.getElementById("phonenum").innerHTML = ownersArray[i].phone;
+				document.getElementById("emailadd").innerHTML = ownersArray[i].email;
+				break;
+			}
+		}
 	} else {
 		document.getElementById("phonenum").innerHTML = '';
 		document.getElementById("emailadd").innerHTML = '';
-		document.getElementById("oPhone").value = '';
-		document.getElementById("oEmail").value = '';
 	}
 	statusChange();
 }

--- a/files/header.php
+++ b/files/header.php
@@ -1,8 +1,6 @@
 <?php
 	$path=substr(getcwd(), strrpos(getcwd(), '/') + 1);
-	if ($path=="admin") {$path="../files/style.css";} 
-	elseif ($path=="files") {$path="style.css";} 
-	else {$path="files/style.css";}
+	if ($path=="admin") {$path="../files/style.css";} elseif ($path=="files") {$path="style.css";} else {$path="files/style.css";}
 ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">

--- a/files/include.php
+++ b/files/include.php
@@ -21,7 +21,7 @@
 	$success = 'noscreen ';
 	$logout = $admin."secure.php?logout=1";
 
-	if ($_GET['id']) {
+	if ($_GET['id']) {							//This is not needed. Use ternary operators on each statement and remove this if/else.
 		$where = "WHERE ID=".$_GET['id'];
 		$pwhere = "WHERE vehicle=".$_GET['id'];
 		$ewhere = "WHERE ID=".$_SESSION['eid'];
@@ -43,6 +43,9 @@
 	
 	//Vehicles - Prepare query to update all fields (except purchprice and purchdate) where ID=$_GET['ID']
 	$update = $db->prepare("UPDATE vehicles SET vin=:vin, year=:year, make=:make, model=:model, trim=:trim, miles=:miles, owner=:owner, askprice=:askprice, intnotes=:intnotes, pubnotes=:pubnotes, status=:status, insured=:insured, payment=:payment, paynotes=:paynotes ".$where);
+
+	$updateDesc = $db->prepare("UPDATE vehicles SET pubnotes=:pubnotes WHERE ID=".$_GET['id']);
+	$updateInternal = $db->prepare("UPDATE vehicles SET intnotes=:intnotes WHERE ID=".$_GET['id']);
 	
 	//Vehicles - Prepare query to select (if $_GET[;ID;] exists, return all info for only that vehicle; else return all info for all vehicles) [may want to break into two 
 	//select statements for efficiency]

--- a/files/include.php
+++ b/files/include.php
@@ -33,9 +33,11 @@
 
 	//Users Table
 	$selectUsers = $db->prepare("SELECT * FROM users WHERE username=:name");
-	//$insert = $db->prepare("INSERT INTO users (username,hash) VALUES (:user,:hash)");
+	$selectAllUsers = $db->prepare("SELECT * FROM users ORDER BY fname ASC");
+	$insertUsers = $db->prepare("INSERT INTO users (username,hash,fname,lname,isadmin) VALUES (:user,:pass,:fname,:lname,:isadmin)");
 	$updateUsers = $db->prepare("UPDATE users SET hash = :pass WHERE username = :name");
-	
+	$deleteUser = $db->prepare("DELETE FROM users WHERE id=:id");
+
 	//Vehicles - Prepare query to insert year, make, model, & trim as new record into database
 	$insert = $db->prepare("INSERT INTO vehicles (year,make,model,trim) VALUES (:year,:make,:model,:trim)");
 	
@@ -50,8 +52,10 @@
 
 	//Owners Table
 	$oFields = array('name', 'email', 'phone');														//Used for Insert/Update
+	$oInsert = $db->prepare("INSERT INTO owners (name,email,phone) VALUES(:name,:email,:phone)");	//Add owners
 	$oSelect = $db->prepare("SELECT * FROM owners");												//Create query to select all owners
 	$oSelect1 = $db->prepare("SELECT * FROM owners WHERE id=:oid");
+	$deleteOwner = $db->prepare("DELETE FROM owners WHERE id=:id");
 	$oSelect->execute();																			//Execute query
 	$oRows = $oSelect->fetchAll(PDO::FETCH_ASSOC);													//Fill array with results
 

--- a/files/include.php
+++ b/files/include.php
@@ -42,7 +42,7 @@
 	$insert = $db->prepare("INSERT INTO vehicles (year,make,model,trim) VALUES (:year,:make,:model,:trim)");
 	
 	//Vehicles - Prepare query to update all fields (except purchprice and purchdate) where ID=$_GET['ID']
-	$update = $db->prepare("UPDATE vehicles SET vin=:vin, year=:year, make=:make, model=:model, trim=:trim, miles=:miles, owner=:owner, askprice=:askprice, intnotes=:intnotes, pubnotes=:pubnotes, status=:status, insured=:insured, payment=:payment, paynotes=:paynotes ".$where);
+	$update = $db->prepare("UPDATE vehicles SET vin=:vin, year=:year, make=:make, model=:model, trim=:trim, miles=:miles, owner=:owner, askprice=:askprice, status=:status, insured=:insured, payment=:payment, paynotes=:paynotes ".$where);
 
 	$updateDesc = $db->prepare("UPDATE vehicles SET pubnotes=:pubnotes WHERE ID=".$_GET['id']);
 	$updateInternal = $db->prepare("UPDATE vehicles SET intnotes=:intnotes WHERE ID=".$_GET['id']);

--- a/files/menu.php
+++ b/files/menu.php
@@ -1,5 +1,5 @@
 <a href="../">Home</a>
 <a href="../admin">Admin</a>
 <a href="../files/settings.php">Settings</a>
-<a href="#">Customers</a><br/><br/>
+<!--<a href="#">Customers</a>--><br/><br/>
 <a href="../admin/secure.php?logout=1">Logout</a>

--- a/files/settings.php
+++ b/files/settings.php
@@ -186,9 +186,9 @@
 		</div>
 		<div id="mainContainer" class="bgblue bord5 b-rad15 m-lrauto center m-top25">
 			<div class="settings-header">Settings Page</div><br/>
-			<button class="tablink" onclick="openTab('Database', this)"<?php echo (!$_SESSION['settings']?" id=\"defaultOpen\"":"");?>>Database</button>
-			<button class="tablink" onclick="openTab('Owners', this)"<?php echo ($_SESSION['settings']=='owners'?" id=\"defaultOpen\"":"");?>>Owners</button>
-			<button class="tablink" onclick="openTab('Users', this)"<?php echo ($_SESSION['settings']=='users'?" id=\"defaultOpen\"":"");?>>Users</button>
+			<button class="tablink width33" onclick="openTab('Database', this, 'left')"<?php echo (!$_SESSION['settings']?" id=\"defaultOpen\"":"");?>>Database</button>
+			<button class="tablink width33" onclick="openTab('Owners', this, 'middle')"<?php echo ($_SESSION['settings']=='owners'?" id=\"defaultOpen\"":"");?>>Owners</button>
+			<button class="tablink width33" onclick="openTab('Users', this, 'right')"<?php echo ($_SESSION['settings']=='users'?" id=\"defaultOpen\"":"");?>>Users</button>
 			<div id="Database" class="tabcontent">
 				<form action="<?php echo htmlspecialchars($_SERVER["PHP_SELF"]);?>" method="post">
 					<table class="settings">
@@ -209,7 +209,7 @@
 					</table><br/>
 					<?php 
 						if (isset($_SESSION['run'])) {
-							echo $_SESSION['results']."<br/>";
+							echo $_SESSION['results']."<br/><br/>";
 							$_SESSION['run']+=1;
 						}
 						echo ($created_tables?($created_tables===true?

--- a/files/settings.php
+++ b/files/settings.php
@@ -9,13 +9,13 @@
 	if (!file_exists("config.ini.php") || isset($_POST['Save'])) {
 		$file="<?php \n/*;\n[connection]\ndbname = \"".($_POST["dbname"]?:"")."\"\nhost = \"".($_POST["host"]?:"").
 		"\"\nusername = \"".($_POST["username"]?:"")."\"\npassword = \"".($_POST["password"]?:"")."\"\nbranch = \"".
-		($_POST["branch"]?:"")."\"\ncommit = \"".($ini['commit']?:"")."\"\n*/\n?>";
+		($_POST["branch"]?:"")."\"\ncommit = \"".($_SESSION['inicommit']?:"")."\"\n*/\n?>";
 		file_put_contents("config.ini.php", $file);
 	}
 
 	//Read config.ini.php
 	$ini = parse_ini_file("config.ini.php");
-	
+	$_SESSION['inicommit']=$ini['commit'];
 	//Test validity of database, host, & credentials
 	require_once("dbcheck.php");
 	$hostChk = (!$ini["host"]?"Required Field":($array["connTest"]?($array["connTest"]!="Pass"?$array["connTest"]:""):""));

--- a/files/settings.php
+++ b/files/settings.php
@@ -155,42 +155,50 @@
 		  <div class="bar2"></div>
 		  <div class="bar3"></div>
 		</div>
-		<div id="mainContainer" class="bgblue bord5 p15 b-rad15 m-lrauto center m-top25">
+		<div id="mainContainer" class="bgblue bord5 b-rad15 m-lrauto center m-top25">
 			<div class="settings-header">Settings Page</div><br/>
-			<form action="<?php echo htmlspecialchars($_SERVER["PHP_SELF"]);?>" method="post">
-				<table class="settings">
-					<tr><td>Host Name:</td><td><input name="host" type="textbox"<?php echo $hostChk;?> value="<?php echo $ini["host"];?>"></td></tr>
-					<tr><td nowrap>Database Name:</td><td><input name="dbname" type="textbox"<?php echo $dbChk;?> value="<?php echo $ini["dbname"];?>"></td></tr>
-					<tr><td>Username:</td><td><input name="username" type="textbox"<?php echo $userChk;?> value="<?php echo $ini["username"];?>"></td></tr>
-					<tr><td>Password:</td><td><input name="password" type="password"<?php echo $userChk;?> value="<?php echo $ini["password"];?>"></td></tr>
-					<tr><td>Git Branch:</td><td style="text-align:left;">
-						<select name="branch">
-							<?php 
-								foreach(getBranchInfo()['branches'] as $branch=>$value) {
-									if(!$ini["branch"]) {$ini["branch"]="master";}
-									echo "<option value'$branch'".($branch==$ini["branch"]?" selected":"").">$branch</option>";
-								}
-							?>
-						</select>
-					</td></tr>
-				</table>
-				<br/>
-				<?php 
-					if (isset($_SESSION['run'])) {
-						echo $_SESSION['results']."<br/>";
-						$_SESSION['run']+=1;
-					}
-					echo ($created_tables?($created_tables===true?
-						"Tables created successfully.<br/>":"There was a problem creating the table(s).<br/>"):"");
-					echo $userMessage;
-					echo (getBranchInfo($ini['commit'],$ini['branch'])['new']['aheadby']?:"");
-					echo "<input type=\"Submit\" name=\"Save\" value=\"Save\">&nbsp;";
-					echo "<input type=\"Submit\" name=\"Update\" value=\"Update Application\" title=\"Install updates from GitHub\">";
-					if (dbExists) {echo $button?:"";}
-				?>
-			</form>
+			<button class="tablink" onclick="openTab('Database', this)" id="defaultOpen">Database</button>
+			<button class="tablink" onclick="openTab('Owners', this)">Owners</button>
+			<button class="tablink" onclick="openTab('Users', this)">Users</button>
+			<div id="Database" class="tabcontent">
+				<form action="<?php echo htmlspecialchars($_SERVER["PHP_SELF"]);?>" method="post">
+					<table class="settings">
+						<tr><td>Host Name:</td><td><input name="host" type="textbox"<?php echo $hostChk;?> value="<?php echo $ini["host"];?>"></td></tr>
+						<tr><td nowrap>Database Name:</td><td><input name="dbname" type="textbox"<?php echo $dbChk;?> value="<?php echo $ini["dbname"];?>"></td></tr>
+						<tr><td>Username:</td><td><input name="username" type="textbox"<?php echo $userChk;?> value="<?php echo $ini["username"];?>"></td></tr>
+						<tr><td>Password:</td><td><input name="password" type="password"<?php echo $userChk;?> value="<?php echo $ini["password"];?>"></td></tr>
+						<tr><td>Git Branch:</td><td style="text-align:left;">
+							<select name="branch">
+								<?php 
+									foreach(getBranchInfo()['branches'] as $branch=>$value) {
+										if(!$ini["branch"]) {$ini["branch"]="master";}
+										echo "<option value='$branch'".($branch==$ini["branch"]?" selected":"").">$branch</option>";
+									}
+								?>
+							</select>
+						</td></tr>
+					</table>
+					<br/>
+					<?php 
+						if (isset($_SESSION['run'])) {
+							echo $_SESSION['results']."<br/>";
+							$_SESSION['run']+=1;
+						}
+						echo ($created_tables?($created_tables===true?
+							"Tables created successfully.<br/>":"There was a problem creating the table(s).<br/>"):"");
+						echo $userMessage;
+						echo (getBranchInfo($ini['commit'],$ini['branch'])['new']['aheadby']?:"");
+						echo "<input type=\"Submit\" name=\"Save\" value=\"Save\">&nbsp;";
+						echo "<input type=\"Submit\" name=\"Update\" value=\"Update Application\" title=\"Install updates from GitHub\">";
+						if (dbExists) {echo $button?:"";}
+					?>
+				</form>
+			</div>
+			<div id="Owners" class="tabcontent">Owners Content</div>
+			<div id="Users" class="tabcontent">Users Content</div>
 		</div>
 	</div>
 	<div class="commit"><?php echo $ini['commit'];?></div>
 	<script src="admin.js"></script>
+	<script>document.getElementById("defaultOpen").click();</script>
 </body>

--- a/files/settings.php
+++ b/files/settings.php
@@ -3,35 +3,10 @@
 	define('included', TRUE);
 	require_once($files."header.php");
 	ini_set("allow_url_fopen", 1);
-	
-	//Pull branch info from GitHub
-	function getBranchInfo($commit = null,$branch = null) {
-		$json = getJSON("branches");
-		foreach($json as $item) {$info['branches'][$item['name']]=$item['commit']['sha'];}
-		if($commit) {
-			$json = getJSON("commits/".$commit);
-			$info['current']=array("commit"=>$json['sha'],"date"=>str_replace("Z","",str_replace("T"," ",$json['commit']['committer']['date'])),"notes"=>$json['commit']['message']);
-		}
-		if($branch) {
-			$json=getJSON("branches/".$branch);
-			$info['new']=array("name"=>$json['name'],"commit"=>$json['commit']['sha'],"date"=>str_replace("Z","",str_replace("T"," ",$json['commit']['commit']['committer']['date'])));
-		}
-		if (($commit) && ($branch) && ($info['current']['commit']!=$info['new']['commit'])) {
-			$json = getJSON("compare/".$info['current']['commit']."...".$info['new']['commit']);
-			if ($json['status']=="ahead") {
-				$info['new']['aheadby']="<div class='red bold'>Update available. ".$json['ahead_by']." commit(s) behind.</div><br/>";
-			}
-		}
-		return $info;
-	}
-	function getJSON($url) {
-		$url = "https://api.github.com/repos/dynamiccookies/dadsgarage/".$url;
-		return json_decode(file_get_contents($url, false, stream_context_create(array('http' => array('user_agent'=> $_SERVER['HTTP_USER_AGENT'])))),true);
-	}
 	$userMessage = "";
+
 	//Create/update config.ini.php
 	if (!file_exists("config.ini.php") || isset($_POST['Save'])) {
-		//if (isset($_POST['Save'])) {}
 		$file="<?php \n/*;\n[connection]\ndbname = \"".($_POST["dbname"]?:"")."\"\nhost = \"".($_POST["host"]?:"").
 		"\"\nusername = \"".($_POST["username"]?:"")."\"\npassword = \"".($_POST["password"]?:"")."\"\nbranch = \"".
 		($_POST["branch"]?:"")."\"\ncommit = \"".($ini['commit']?:"")."\"\n*/\n?>";
@@ -70,18 +45,49 @@
 		//Check existence/create default Admin user
 		$userExists=usersExist();
  		if ($userExists===TRUE) {
-			$userMessage = "The default username and password are 'admin'.<br/>
-			<a href='../admin'>Click here to change the password.</a><br/><br/>";
+			$userMessage = "The default username and password are 'admin'.<br/><a href='../admin'>Click here to change the password.</a><br/><br/>";
 		} elseif (!$userExists===FALSE) {
 			if (strpos($userExists,"Base table or view not found")!==FALSE) {
-				$userMessage = "The Users table does not exist.<br/>
-				Please click the Create Table(s) button to create it.<br/><br/>";
-			} elseif (strpos($userExists,"Access denied for user '".$_POST['username']."'")) {
-				$userMessage = "The username or password is incorrect.<br/><br/>";
+				$userMessage = "The Users table does not exist.<br/>Please click the Create Table(s) button to create it.<br/><br/>";
+			} elseif (strpos($userExists,"Access denied for user '".$_POST['username']."'")) {$userMessage = "The username or password is incorrect.<br/><br/>";
 			} else {$userMessage = $userExists;}
 		} elseif($userExists===FALSE) {require("../admin/secure.php");}
 	}
-
+	if(!isset($_POST['ownerAdd']) && !isset($_POST['userAdd'])) {unset($_SESSION['settings']);}
+	if(isset($_POST['ownerAdd'])) {
+		$oInsert->bindParam(':name',$_POST['name']);
+		$oInsert->bindParam(':phone',$_POST['phone']);
+		$oInsert->bindParam(':email',$_POST['email']);
+		$oInsert->execute();
+		$_SESSION['settings'] = 'owners';
+	}
+	if(isset($_POST['userAdd'])) {
+		$_POST['isadmin']?:$_POST['isadmin']=0;
+		$insertUsers->bindParam(':user',strtolower($_POST['user']));
+		$insertUsers->bindParam(':pass',password_hash($_POST['user'], PASSWORD_DEFAULT));
+		$insertUsers->bindParam(':fname',$_POST['fname']);
+		$insertUsers->bindParam(':lname',$_POST['lname']);
+		$insertUsers->bindParam(':isadmin',$_POST['isadmin'],PDO::PARAM_BOOL);
+		$insertUsers->execute();
+		$_SESSION['settings'] = 'users';
+	}
+	if(isset($_POST['resetUser'])) {
+		$updateUsers->bindParam(':name',$_POST['user']);
+		$updateUsers->bindParam(':pass',password_hash($_POST['user'], PASSWORD_DEFAULT));
+		$updateUsers->execute();
+		$_SESSION['settings'] = 'users';
+	}
+	if(isset($_POST['deleteUser'])) {
+		$deleteUser->bindParam(':id',$_POST['deleteID']);
+		$deleteUser->execute();
+		$_SESSION['settings'] = 'users';
+	}
+	if(isset($_POST['deleteOwner'])) {
+		$deleteOwner->bindParam(':id',$_POST['deleteID']);
+		$deleteOwner->execute();
+		$_SESSION['settings'] = 'owners';
+	}
+	
 	//Update Application from GitHub
 	if (isset($_POST['Update'])) {
   		try {
@@ -132,6 +138,29 @@
 		unset($_SESSION['run']);
 	}
 
+	//Pull branch info from GitHub
+	function getBranchInfo($commit = null,$branch = null) {
+		$json = getJSON("branches");
+		foreach($json as $item) {$info['branches'][$item['name']]=$item['commit']['sha'];}
+		if($commit) {
+			$json = getJSON("commits/".$commit);
+			$info['current']=array("commit"=>$json['sha'],"date"=>str_replace("Z","",str_replace("T"," ",$json['commit']['committer']['date'])),"notes"=>$json['commit']['message']);
+		}
+		if($branch) {
+			$json=getJSON("branches/".$branch);
+			$info['new']=array("name"=>$json['name'],"commit"=>$json['commit']['sha'],"date"=>str_replace("Z","",str_replace("T"," ",$json['commit']['commit']['committer']['date'])));
+		}
+		if (($commit) && ($branch) && ($info['current']['commit']!=$info['new']['commit'])) {
+			$json = getJSON("compare/".$info['current']['commit']."...".$info['new']['commit']);
+			if ($json['status']=="ahead") {$info['new']['aheadby']="<div class='red bold'>Update available. ".$json['ahead_by']." commit(s) behind.</div><br/>";}
+		}
+		return $info;
+	}
+	function getJSON($url) {
+		$url = "https://api.github.com/repos/dynamiccookies/dadsgarage/".$url;
+		return json_decode(file_get_contents($url, false, stream_context_create(array('http' => array('user_agent'=> $_SERVER['HTTP_USER_AGENT'])))),true);
+	}
+
 /* Testing Database Creation - Future Release
 	if (substr_count($dbChk,"does not exist.")>0) {
 		$mkDB="<form action=\"<?php echo htmlspecialchars($_SERVER["PHP_SELF"]);?>\" method=\"post\"><input type=\"Submit\" name=\"mkDB\" value=\"Create Database\"></form>";
@@ -157,9 +186,9 @@
 		</div>
 		<div id="mainContainer" class="bgblue bord5 b-rad15 m-lrauto center m-top25">
 			<div class="settings-header">Settings Page</div><br/>
-			<button class="tablink" onclick="openTab('Database', this)" id="defaultOpen">Database</button>
-			<button class="tablink" onclick="openTab('Owners', this)">Owners</button>
-			<button class="tablink" onclick="openTab('Users', this)">Users</button>
+			<button class="tablink" onclick="openTab('Database', this)"<?php echo (!$_SESSION['settings']?" id=\"defaultOpen\"":"");?>>Database</button>
+			<button class="tablink" onclick="openTab('Owners', this)"<?php echo ($_SESSION['settings']=='owners'?" id=\"defaultOpen\"":"");?>>Owners</button>
+			<button class="tablink" onclick="openTab('Users', this)"<?php echo ($_SESSION['settings']=='users'?" id=\"defaultOpen\"":"");?>>Users</button>
 			<div id="Database" class="tabcontent">
 				<form action="<?php echo htmlspecialchars($_SERVER["PHP_SELF"]);?>" method="post">
 					<table class="settings">
@@ -177,8 +206,7 @@
 								?>
 							</select>
 						</td></tr>
-					</table>
-					<br/>
+					</table><br/>
 					<?php 
 						if (isset($_SESSION['run'])) {
 							echo $_SESSION['results']."<br/>";
@@ -194,8 +222,69 @@
 					?>
 				</form>
 			</div>
-			<div id="Owners" class="tabcontent">Owners Content</div>
-			<div id="Users" class="tabcontent">Users Content</div>
+			<div id="Owners" class="tabcontent">
+				<?php $owners=$oRows;?>
+				<form action="<?php echo htmlspecialchars($_SERVER["PHP_SELF"]);?>" method="post">
+					<table class="settings">
+						<tr><td>Name:</td><td><input name="name" type="textbox" value=""></td></tr>
+						<tr><td>Phone:</td><td><input name="phone" type="textbox" value=""></td></tr>
+						<tr><td>Email:</td><td><input name="email" type="textbox" value=""></td></tr>
+					</table><br/>
+					<input type="Submit" name="ownerAdd" value="Add"><br/><br/>
+				</form>
+				<table id="owners">
+					<tr><th>Name</th><th>Phone</th><th>Email</th><th>Delete</th></tr>
+					<?php foreach($owners as $owner) {?>
+							<tr>
+								<td><?php echo $owner['name']?></td>
+								<td><?php echo $owner['phone']?></td>
+								<td><?php echo $owner['email']?></td>
+								<td>
+									<form action='<?php echo htmlspecialchars($_SERVER["PHP_SELF"])?>' method='post'>
+										<input type='hidden' name='deleteID' value='<?php echo $owner['id']?>'>
+										<input type='submit' name='deleteOwner' value='Delete'>
+									</form>
+								</td>
+							</tr>
+					<?php }?>
+				</table>
+			</div>
+			<div id="Users" class="tabcontent">
+				<?php $selectAllUsers->execute();$users=$selectAllUsers->fetchAll(PDO::FETCH_ASSOC);?>
+				<form action="<?php echo htmlspecialchars($_SERVER["PHP_SELF"]);?>" method="post">
+					<table class="settings">
+						<tr><td>Username:</td><td><input name="user" type="textbox" value=""></td></tr>
+						<tr><td nowrap>First Name:</td><td><input name="fname" type="textbox" value=""></td></tr>
+						<tr><td>Last Name:</td><td><input name="lname" type="textbox" value=""></td></tr>
+						<tr><td>Is Admin?</td><td style="text-align:left;"><input name="isadmin" type="checkbox" value="1"></td></tr>
+						<tr><td colspan=2>*On add and reset, password is equal to the username</td></tr>
+					</table><br/>
+					<input type="Submit" name="userAdd" value="Add"><br/><br/>
+				</form>
+				<table id="users">
+					<tr><th>Username</th><th>First Name</th><th>Last Name</th><th>Is Admin?</th><th>Password</th><th>Delete</th></tr>
+					<?php foreach($users as $user) {?>
+							<tr>
+								<td><?php echo $user['username']?></td>
+								<td><?php echo $user['fname']?></td>
+								<td><?php echo $user['lname']?></td>
+								<td><input type='checkbox' disabled<?php echo $user['isadmin']==1?" checked":""?>></td>
+								<td>
+									<form action='<?php echo htmlspecialchars($_SERVER["PHP_SELF"])?>' method='post'>
+										<input type='hidden' name='user' value='<?php echo $user['username']?>'>
+										<input type='submit' name='resetUser' value='Reset'>
+									</form>
+								</td>
+								<td>
+									<form action='<?php echo htmlspecialchars($_SERVER["PHP_SELF"])?>' method='post'>
+										<input type='hidden' name='deleteID' value='<?php echo $user['id']?>'>
+										<input type='submit' name='deleteUser' value='Delete'>
+									</form>
+								</td>
+							</tr>
+					<?php }?>
+				</table>
+			</div>
 		</div>
 	</div>
 	<div class="commit"><?php echo $ini['commit'];?></div>

--- a/files/style.css
+++ b/files/style.css
@@ -66,6 +66,35 @@
 	}
 	#main .vehicle img {height: 200px;}
 	#main .red {border-color: red;}
+	table#users, table#owners {
+		margin-left:auto;
+		margin-right:auto;
+		border-collapse: collapse;
+		box-shadow: 10px 10px 10px grey;
+	}
+	table#owners tr:nth-child(odd) {
+		background-color: #daecee;
+	}
+	table#owners tr:nth-child(even) {
+		background-color: white;
+	}
+	table#users tr:nth-child(odd){
+		background-color: #daecee;
+	}
+	table#users tr:nth-child(even){
+		background-color: white;
+	}
+	table#users th, table#owners th {
+		font-weight:bold;
+	}
+	table#owners td, table#owners th {
+		border: 1px solid silver;
+		padding: 5px;
+	}
+	table#users td, table#users th {
+		border: 1px solid silver;
+		padding: 5px;
+	}
 	.tablink {
 		float: left;
 		border: none;
@@ -82,6 +111,7 @@
 		padding-top:75px;
 		text-align: center;
 		background-color: silver;
+		border-radius: 0px 0px 10px 10px;
 	}
 	.bb, table.photos td, .tbl-align td  {
 		border-bottom: 1px solid black!important;

--- a/files/style.css
+++ b/files/style.css
@@ -95,6 +95,11 @@
 		border: 1px solid silver;
 		padding: 5px;
 	}
+	#SubmitInternal,#SubmitDesc {
+		float:right;
+		margin:25px;
+		margin-right:100px;
+	}
 	.tablink {
 		float: left;
 		border: none;
@@ -102,13 +107,17 @@
 		cursor: pointer;
 		padding: 14px 16px;
 		font-size: 17px;
-		width: 33.333333%;
 	}
+	.tablink:hover {font-weight:bold !important;}
+	.width20 {width: 20%;}
+	.width25 {width: 25%;}
+	.width33 {width: 33.333333%;}
 	.tabcontent {
 		color: black;
 		display: none;
 		padding: 20px;
 		padding-top:75px;
+		padding-bottom:71px;
 		text-align: center;
 		background-color: silver;
 		border-radius: 0px 0px 10px 10px;
@@ -116,6 +125,7 @@
 	.bb, table.photos td, .tbl-align td  {
 		border-bottom: 1px solid black!important;
 	}
+	.photos {border-collapse:collapse;}
 	.td-align {padding-left:10px;text-align:left !important;}
 	.content {
 		width: 80%;
@@ -166,9 +176,9 @@
 	.m-right {margin-right:25px;}
 	.viewing {border-collapse: collapse;border-spacing: 25px 0px;}
 	.bgblue {background-color:#daecee;}
-	.bord5 {border: 5px solid gray;}
+	.bord5, textarea {border: 5px solid gray;}
 	.b-right1 {border-right: 1px solid;}
-	.b-rad15 {border-radius: 15px;}
+	.b-rad15, textarea {border-radius: 15px;}
 	.center {text-align: center;}
 	.fleft {float: left;}
 	.fright {float: right;}
@@ -283,12 +293,12 @@
 	}
 
 	#adminSidenav.change {
-		width:250px;
+		width:175px;
 		transition: width .5s;
 	}
 
 	#adminMain.change {
-		margin-left:250px;
+		margin-left:175px;
 		transition: margin-left .5s;
 	}
 	div#mainContainer {

--- a/files/style.css
+++ b/files/style.css
@@ -66,6 +66,23 @@
 	}
 	#main .vehicle img {height: 200px;}
 	#main .red {border-color: red;}
+	.tablink {
+		float: left;
+		border: none;
+		outline: none;
+		cursor: pointer;
+		padding: 14px 16px;
+		font-size: 17px;
+		width: 33.333333%;
+	}
+	.tabcontent {
+		color: black;
+		display: none;
+		padding: 20px;
+		padding-top:75px;
+		text-align: center;
+		background-color: silver;
+	}
 	.bb, table.photos td, .tbl-align td  {
 		border-bottom: 1px solid black!important;
 	}
@@ -81,6 +98,7 @@
 	.settings-header {
 		font-size:36px;
 		font-weight:bold;
+		padding-top: 15px;
 	}
 	.required {
 		box-shadow:0 0 5px #ff0000;
@@ -245,7 +263,7 @@
 	}
 	div#mainContainer {
 		margin-top: -50px;
-		width:33%; 
+		min-width: 609px;
 		max-width:66%;
 		display:table;
 	}

--- a/vehicle.php
+++ b/vehicle.php
@@ -1,4 +1,8 @@
 <?php
+	if(!$_GET['id']) {
+		header('Location: index.php');
+		exit;
+	}
 	require("files/include.php");
 	date_default_timezone_set("America/Chicago"); //What is this for??
 


### PR DESCRIPTION
## New
- Added Owners and Users management to the `files/settings.php` page
    - Used new tab structure to flip between Database, Owners, & Users
    - Owners and Users tabs allow for adding/deleting users and resetting passwords where necessary
        - They each include a full list of their respective owners/users
    - Page remembers which tab you were on when making changes/postback

## Updated
- Completely overhauled `admin/edit.php` page to use new tab structure and dark theme
    - Page remembers which tab you were on when making changes/postback
    - Moved Description and Internal `textarea` fields to their own tabs and their own Save buttons
    - Removed Owner Edit feature since this is now taken care of on the `files/settings.php` Owners tab
    - Changed button text:
        - "Submit All Changes" :arrow_right: "Save"
        - Files' "Send files" :arrow_right: "Upload files"
        - Photos' "Send files" :arrow_right: "Upload photos"

## Fixed
- (#16) Bug in `admin/edit.php` when page was accessed without `?id=` querystring
    - Fixed by checking for querystring and forcing back to `admin/index.php` if not found
    - Expanded this fix to `vehicles.php` page
- Bug in `files/edit.js` that would not populate owners if any IDs were missing (i.e. 1,3,4 but not 2)
    - JavaScript was comparing owner ID to `<select>` drop-down value
    - Fixed by looping through entire list of owners `onChange` to find correct info
- Bug in `files/settings.php` where commit was not saved when branch was changed
    - Fixed by storing commit value into `session` variable and writing to `files/commit.ini.php` after update