### PR TITLE
Closes #36 - Updated `tableExists()` function

### DIFF
--- a/files/settings.php
+++ b/files/settings.php
@@ -38,16 +38,8 @@
 	if (strpos($hostChk, 'pass') && strpos($dbChk, 'pass') && strpos($userChk, 'pass') && strpos($passChk, 'pass')) {
 		$dbExists = true;
 
-		if (
-			!tableExists('customers') ||
-			!tableExists('expenses')  ||
-			!tableExists('files')     ||
-			!tableExists('owners')    ||
-			!tableExists('photos')    ||
-			!tableExists('users')	  ||
-			!tableExists('vehicles')
-		) {
-			if ($_POST['createTables']) {
+		if (!check_tables()) {
+			if (isset($_POST['createTables'])) {
 				$createdTables = createTables();
 			} else {
 				$button = " <input type='Submit' name='createTables' value='Create Table(s)'>";
@@ -73,7 +65,7 @@
 	} else {$dbExists = false;}
 
 	if($dbExists) {
-		if (tableExists('users')) {
+		if (check_tables('users')) {
 			$_SESSION['include'] = true;
 			require_once '../includes/include.php';
 		}
@@ -403,7 +395,7 @@
 			</div>
 			<div id='Owners' class='tabcontent'>
 				<?php 
-					if ($dbExists && tableExists('owners')) {
+					if ($dbExists && check_tables('owners')) {
 						$_SESSION['include'] = true;
 						require_once '../includes/include.php';
 						$oSelect->execute();
@@ -442,7 +434,7 @@
 			<div id='Users' class='tabcontent'>
  				<?php 
 				if($dbExists){
-					if(tableExists('users')){
+					if(check_tables('users')){
 						$_SESSION['include'] = true;
 						require_once '../includes/include.php';
 						$selectAllUsers->execute();
@@ -505,7 +497,7 @@
 	<script src='../scripts/admin.js'></script>
 	<script>
 		<?php
-			if($dbExists && tableExists('owners')) {
+			if($dbExists && check_tables('owners')) {
 				$selectAllUsernames = $db->prepare('SELECT username FROM users ORDER BY fname ASC');
 				$selectAllUsernames->execute();
 				$usernames = $selectAllUsernames->fetchAll(PDO::FETCH_ASSOC);

--- a/includes/initialize-database.php
+++ b/includes/initialize-database.php
@@ -100,23 +100,26 @@
 		catch (PDOException $e) {return 'There was a problem: ' . $e;}
 	}
 
-	//check if a specific table exists
-	function tableExists($table) {	//https://stackoverflow.com/questions/1717495/check-if-a-database-table-exists-using-php-pdo
+	function check_tables(...$tables) {
+        if (!$tables) {$tables = array('customers', 'expenses', 'files', 'owners', 'photos', 'users', 'vehicles');}
 		$dsn = 'mysql:host=' . $GLOBALS['server'] . ';dbname=' . $GLOBALS['dbName'] . ';port=' . $GLOBALS['port'];
-		// Set options
+
+		// Set PDO options
 		$options = array(
 			PDO::ATTR_ERRMODE            => PDO::ERRMODE_EXCEPTION,
 			PDO::ATTR_PERSISTENT         => true,
 			PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC
 		);
+
 		//Create a new PDO instance
 		try {
 			$conn = new PDO($dsn, $GLOBALS['dbUsername'], $GLOBALS['dbPassword'], $options);
-			$temp = "SELECT 1 FROM ".$table." LIMIT 1";
-			$temp = $conn->query($temp);
+			foreach ($tables as $table) {$conn->query('SELECT 1 FROM ' . $table . ' LIMIT 1');}
+
 			return true;
 		}
 		catch (PDOException $e) {
+			error_log("\n\nERROR in check_tables(): " . $e . "\n\n", 3, 'error_log');
 			return false;
 		}
 	}


### PR DESCRIPTION
- Renamed `tableExists()` function to `check_tables()`
- Updated all references in code to reflect new function name
- Added splat operator to function's `$tables` argument to allow for multiple arguments
- Added check for existence of `$tables` variable - if doesn't exist, set `$table` equal to array of all table names (this allows for function to be called with no arguments when testing all tables)
- Expanded descriptive comment
- Added `foreach` loop to loop through and test all table names
- Consolidated connection query test with `foreach` into one line
- Added custom error logging on try/catch
- Removed all additional calls to the function when testing multiple tables
- Added `isset()` to prevent error when `$_POST['createTables']` doesn't exist

Close #36